### PR TITLE
Fix ID check button on signup page

### DIFF
--- a/member/join_step02.html
+++ b/member/join_step02.html
@@ -448,8 +448,39 @@ include $_SERVER['DOCUMENT_ROOT'] . '/include/header.html';
         });
     }
 </script>
+<script src="http://dmaps.daum.net/map_js_init/postcode.v2.js"></script>
 <script src="/js/form-controller.js"></script>
 <script>
+    document.getElementById('btn_search_addr').addEventListener('click', function (e) {
+        e.preventDefault();
+        new daum.Postcode({
+            oncomplete: function(data) {
+                var addr = '';
+                var extraAddr = '';
+                if (data.userSelectedType === 'R') {
+                    addr = data.roadAddress;
+                } else {
+                    addr = data.jibunAddress;
+                }
+                if (data.userSelectedType === 'R') {
+                    if (data.bname !== '') {
+                        extraAddr += data.bname;
+                    }
+                    if (data.buildingName !== '') {
+                        extraAddr += (extraAddr !== '' ? ', ' + data.buildingName : data.buildingName);
+                    }
+                    if (extraAddr !== '') {
+                        addr += ' (' + extraAddr + ')';
+                    }
+                }
+                document.getElementById('f_addr_zip').value = data.zonecode;
+                document.getElementById('f_addr_basic').value = addr;
+                document.getElementById('f_addr_detail').focus();
+            }
+        }).open();
+    });
+
+    const submitter = new FormSubmitter('join_form');
     document.getElementById("join_form").addEventListener("submit", function (e) {
         e.preventDefault();
         const form = this;
@@ -465,7 +496,7 @@ include $_SERVER['DOCUMENT_ROOT'] . '/include/header.html';
         if (mobile) {
             form.f_mobile.value = `${mobile.slice(0, 3)}-${mobile.slice(3, mobile.length - 4)}-${mobile.slice(mobile.length - 4)}`;
         }
-        submitForm("join_form");
+        submitter.submit();
     });
     document.getElementById('btn_submit').addEventListener('click', function (e) {
         e.preventDefault();


### PR DESCRIPTION
## Summary
- initialize `FormSubmitter` on page load
- submit form via created instance
- integrate Daum postcode search on signup page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68818b0c00e08322b2e426d2ae7b58ac