### PR TITLE
Fix member signup data handling

### DIFF
--- a/controller/member_signup.php
+++ b/controller/member_signup.php
@@ -4,7 +4,29 @@ include $_SERVER['DOCUMENT_ROOT'].'/inc/util_lib.inc';
 
 header('Content-Type: application/json; charset=utf-8');
 
+function digits_only(string $val): string {
+    return preg_replace('/\D/', '', $val);
+}
+
+function sanitize_signup_input(array $data): array {
+    $data = array_map('trim', $data);
+    if (isset($data['f_tel'])) {
+        $data['f_tel'] = digits_only($data['f_tel']);
+    }
+    if (isset($data['f_mobile'])) {
+        $data['f_mobile'] = digits_only($data['f_mobile']);
+    }
+    if (isset($data['f_birth_date'])) {
+        $data['f_birth_date'] = digits_only($data['f_birth_date']);
+        if ($data['f_birth_date'] !== '' && strlen($data['f_birth_date']) !== 8) {
+            json_exit(['result' => 'error', 'msg' => '생년월일은 숫자 8자리로 입력해주세요.']);
+        }
+    }
+    return $data;
+}
+
 $mode = $_POST['mode'] ?? '';
+$post = sanitize_signup_input($_POST);
 
 function json_exit($arr){
     echo json_encode($arr);
@@ -31,7 +53,7 @@ function validate_form($data) {
 }
 
 if($mode === 'check_id'){
-    $userId = trim($_POST['f_user_id'] ?? '');
+    $userId = trim($post['f_user_id'] ?? '');
     if($userId === '') json_exit(['result'=>'error','msg'=>'아이디를 입력해주세요.']);
 
     $hangulCheck = check_id_hangul($userId);
@@ -48,52 +70,52 @@ if($mode !== 'sign_up'){
 }
 
 // 폼 유효성 검사
-$validationError = validate_form($_POST);
+$validationError = validate_form($post);
 if($validationError) {
     json_exit($validationError);
 }
 
 // 중복 확인
-$row = $db->row("SELECT COUNT(*) AS cnt FROM df_site_member WHERE f_user_id = :id", ['id'=>$_POST['f_user_id']]);
+$row = $db->row("SELECT COUNT(*) AS cnt FROM df_site_member WHERE f_user_id = :id", ['id'=>$post['f_user_id']]);
 if($row['cnt']) json_exit(['result'=>'error','msg'=>'이미 사용중인 아이디입니다.']);
 
 // 한글 불가처리
-$hangulCheck = check_id_hangul($_POST['f_user_id']);
+$hangulCheck = check_id_hangul($post['f_user_id']);
 if($hangulCheck) {
     json_exit($hangulCheck);
 }
 
 // 비밀번호 유효성 검사. 4~12자 미만의 영문/숫자 조합만 가능
-if(strlen($_POST['f_password']) < 8 || !preg_match('/[A-Za-z0-9]/', $_POST['f_password'])){
+if(strlen($post['f_password']) < 8 || !preg_match('/[A-Za-z0-9]/', $post['f_password'])){
     json_exit(['result'=>'error','msg'=>'비밀번호는 8자 이상, 영문과 숫자를 조합하여 입력해주세요.']);
 }
 
 // f_password_chk, f_password 비교
-if($_POST['f_password'] !== $_POST['f_password_chk']){
+if($post['f_password'] !== $post['f_password_chk']){
     json_exit(['result'=>'error','msg'=>'비밀번호가 일치하지 않습니다.']);
 }
 
 // 휴대폰 번호 중복확인
-$row = $db->row("SELECT COUNT(*) AS cnt FROM df_site_member WHERE f_mobile = :mobile", ['mobile'=>$_POST['f_mobile']]);
+$row = $db->row("SELECT COUNT(*) AS cnt FROM df_site_member WHERE REPLACE(f_mobile, '-', '') = :mobile", ['mobile'=>$post['f_mobile']]);
 if($row['cnt']) json_exit(['result'=>'error','msg'=>'이미 사용중인 휴대폰 번호입니다.']);
 
 // 이메일 중복확인
-$row = $db->row("SELECT COUNT(*) AS cnt FROM df_site_member WHERE f_email = :email", ['email'=>$_POST['f_email']]);
+$row = $db->row("SELECT COUNT(*) AS cnt FROM df_site_member WHERE f_email = :email", ['email'=>$post['f_email']]);
 if($row['cnt']) json_exit(['result'=>'error','msg'=>'이미 사용중인 이메일입니다.']);
 
-$tel    = $_POST['f_tel']    ?? '';
+$tel    = $post['f_tel']    ?? '';
 $data = [
-    'f_user_id'     => $_POST['f_user_id'],
-    'f_password'    => password_hash($_POST['f_password'], PASSWORD_DEFAULT),
-    'f_user_name'   => $_POST['f_user_name'],
-    'f_birth_date'  => $_POST['f_birth_date'],
+    'f_user_id'     => $post['f_user_id'],
+    'f_password'    => password_hash($post['f_password'], PASSWORD_DEFAULT),
+    'f_user_name'   => $post['f_user_name'],
+    'f_birth_date'  => $post['f_birth_date'],
     'f_tel'         => $tel,
-    'f_mobile'      => $_POST['f_mobile'],
-    'f_email'       => $_POST['f_email'],
-    'f_gender'      => $_POST['f_gender'],
-    'f_addr_zip'    => $_POST['f_addr_zip'],
-    'f_addr_basic'  => $_POST['f_addr_basic'],
-    'f_addr_detail' => $_POST['f_addr_detail'] ?? null,
+    'f_mobile'      => $post['f_mobile'],
+    'f_email'       => $post['f_email'],
+    'f_gender'      => $post['f_gender'],
+    'f_addr_zip'    => $post['f_addr_zip'],
+    'f_addr_basic'  => $post['f_addr_basic'],
+    'f_addr_detail' => $post['f_addr_detail'] ?? null,
     'wip'           => $_SERVER['REMOTE_ADDR'] ?? '',
 ];
 

--- a/member/join_step02.html
+++ b/member/join_step02.html
@@ -24,9 +24,6 @@ include $_SERVER['DOCUMENT_ROOT'] . '/include/header.html';
                         <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>" />
                         <input type="hidden" name="mode" value="sign_up" />
                         <input type="hidden" name="f_honey" value="" />
-                        <input type="hidden" name="f_birth_date" value="" />
-                        <input type="hidden" name="f_tel" value="" />
-                        <input type="hidden" name="f_mobile" value="" />
                         <div class="join_con">
                             <div class="contents_con">
                                 <div class="title_con">
@@ -228,7 +225,7 @@ include $_SERVER['DOCUMENT_ROOT'] . '/include/header.html';
 
                                                         <div class="info_con">
                                                             <div class="input_con">
-                                                                <input type="tel" name="birth_temp"
+                                                                <input type="tel" name="f_birth_date"
                                                                     placeholder="법정생년월일 8자리(예: 2025.01.29)"
                                                                     id="birthdate_input" class="input" data-required="y"
                                                                     data-label="생년월일을" />
@@ -246,7 +243,7 @@ include $_SERVER['DOCUMENT_ROOT'] . '/include/header.html';
 
                                                         <div class="info_con">
                                                             <div class="input_con">
-                                                                <input type="tel" name="tel_temp" id="tel_input"
+                                                                <input type="tel" name="f_tel" id="tel_input"
                                                                     maxlength="13" placeholder="전화번호(‘-’제외)"
                                                                     class="input" onkeydown="onlyNumber(this);"
                                                                     data-label="전화번호를" />
@@ -264,7 +261,7 @@ include $_SERVER['DOCUMENT_ROOT'] . '/include/header.html';
 
                                                         <div class="info_con">
                                                             <div class="input_con">
-                                                                <input type="tel" name="mobile_temp" id="mobile_input"
+                                                                <input type="tel" name="f_mobile" id="mobile_input"
                                                                     maxlength="11" placeholder="휴대폰 번호(‘-’제외)"
                                                                     class="input" onkeydown="onlyNumber(this);"
                                                                     data-required="y" data-label="휴대폰 번호를" />
@@ -484,19 +481,6 @@ include $_SERVER['DOCUMENT_ROOT'] . '/include/header.html';
     const submitter = new FormSubmitter('join_form');
     document.getElementById("join_form").addEventListener("submit", function (e) {
         e.preventDefault();
-        const form = this;
-        const b = form.birth_temp.value.replace(/\D/g, "");
-        if (b.length === 8) {
-            form.f_birth_date.value = `${b.slice(0, 4)}-${b.slice(4, 6)}-${b.slice(6, 8)}`;
-        }
-        const tel = form.tel_temp.value.replace(/\D/g, "");
-        if (tel) {
-            form.f_tel.value = `${tel.slice(0, 3)}-${tel.slice(3, tel.length - 4)}-${tel.slice(tel.length - 4)}`;
-        }
-        const mobile = form.mobile_temp.value.replace(/\D/g, "");
-        if (mobile) {
-            form.f_mobile.value = `${mobile.slice(0, 3)}-${mobile.slice(3, mobile.length - 4)}-${mobile.slice(mobile.length - 4)}`;
-        }
         submitter.submit();
     });
     document.getElementById('btn_submit').addEventListener('click', function (e) {


### PR DESCRIPTION
## Summary
- stop client-side conversion of join fields
- sanitize signup input on the server using helper functions
- check duplicate phone numbers without hyphens

## Testing
- `php -l controller/member_signup.php`
- `php -l member/join_step02.html`


------
https://chatgpt.com/codex/tasks/task_e_6881949861888322a5809d28981fceda